### PR TITLE
Dynamic kopsenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kopsenv
 
-**This is currently a modified version of kopsenv to support using the spotinst kops for versions greater than 1.13.0.** (1.13.1, 1.13.2, 1.14.1, ....)  
+**This is currently a modified version of kopsenv to support using either the vanilla or spotinst kops versions
 
 [Kops](https://github.com/kubernetes/kops) version manager inspired by [tfenv](https://github.com/Zordrak/tfenv).
 
@@ -56,6 +56,7 @@ Install a specific version of Kops. Available options for version:
 
 ```sh
 $ kopsenv install 1.10.0
+$ kopsenv install v1.18.2-f37e7a33d0-spotinst
 $ kopsenv install latest
 $ kopsenv install latest:^1.9
 $ kopsenv install
@@ -76,6 +77,7 @@ Switch a version to use
 
 ```sh
 $ kopsenv use 1.10.0
+$ kopsenv use v1.18.2-f37e7a33d0-spotinst
 $ kopsenv use latest
 $ kopsenv use latest:^1.9
 ```
@@ -89,6 +91,7 @@ Uninstall a specific version of Kops
 
 ```sh
 $ kopsenv uninstall 1.10.0
+$ kopsenv uninstall v1.18.2-f37e7a33d0-spotinst
 $ kopsenv uninstall latest
 $ kopsenv uninstall latest:^1.9
 ```

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -22,7 +22,7 @@ function curlw () {
     TLS_OPT=""
   fi
 
-  curl -w "HTTP_RESPONSE_CODE: %{http_code}" ${TLS_OPT} "$@"
+  curl -w "HTTP_RESPONSE_CODE: %{http_code} \n" ${TLS_OPT} "$@"
 }
 
 kops_platform() {

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -22,7 +22,7 @@ function curlw () {
     TLS_OPT=""
   fi
 
-  curl ${TLS_OPT} "$@"
+  curl -w "HTTP_RESPONSE_CODE: %{http_code}" ${TLS_OPT} "$@"
 }
 
 kops_platform() {

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -39,45 +39,13 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-case $version_requested in
-  1.18.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.18.2-6837c742a1"
-    ;;
-  1.17.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.2-e4f69d94ce"
-    ;;
-  1.17.1)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.17.1-8996e8f0f7"
-    ;;
-  1.16.0)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.16.0-84c9a54b4"
-    ;;
 
-  1.15.2)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.2-519eaa64c"
-    ;;
-
-  1.15.1)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.1-6c8e6908c"
-    ;;
-
-  1.15.0)
-    info "Will use a spotinst kops" && \
-    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/v1.15.0-b41e6e0da"
-    ;;
-
-  *)
-    info "Will use the normal kops" && \
+if [[ $version_requested == *-spotinst ]]
+then
+    version_url="https://github.com/spotinst/kubernetes-kops/releases/download/"${version%"-spotinst"}
+else
     version_url="https://github.com/kubernetes/kops/releases/download/${version}"
-    ;;
-
-esac
+fi
 
 exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -17,9 +17,17 @@ platform="$(kops_platform)"
 # only curl + POSIX tools
 json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
-
-echo "$json" \
+json2=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases\?per_page=100)
+(( "$?" )) && exit $?
+output="$(echo "${json}" \
   | grep 'download/[v]\?[0-9\.]\{1,\}/kops-'$platform'"' \
-  | sed 's/^.*download\///; s/\/.*$//' \
+  | sed 's/^.*download\///; s/\/.*$//')"
+
+output="${output}
+$(echo "${json2}" \
+  | grep 'download/[v]\?[0-9\.].*/kops-'$platform'"' \
+  | sed 's/^.*download\///; s/\/.*$/-spotinst/')"
+
+echo "$output" \
   | sort -t. -r -k1,1 -k2,2 -k3,3 -k4,4 \
   | uniq

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,9 +15,26 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
+
 json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
+http_status=$(echo "$json" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
+if [[ http_status != 2* ]]
+then
+   echo "Github API response error:
+$json"
+   exit 1
+fi 
+
 json2=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases\?per_page=100)
+http_status=$(echo "$json2" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
+if [[ http_status != 2* ]] 
+then 
+   echo "Github API response error:
+${json2}"
+   exit 1
+fi 
+
 (( "$?" )) && exit $?
 output="$(echo "${json}" \
   | grep 'download/[v]\?[0-9\.]\{1,\}/kops-'$platform'"' \

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -19,7 +19,7 @@ platform="$(kops_platform)"
 json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases\?per_page=100)
 (( "$?" )) && exit $?
 http_status=$(echo "$json" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
-if [[ http_status != 2* ]]
+if [[ "${http_status}" != 2* ]]
 then
    echo "Github API response error:
 $json"
@@ -28,7 +28,7 @@ fi
 
 json2=$(curlw -s -L https://api.github.com/repos/spotinst/kubernetes-kops/releases\?per_page=100)
 http_status=$(echo "$json2" | grep HTTP_RESPONSE_CODE |  awk '{print $2}')
-if [[ http_status != 2* ]] 
+if [[ "${http_status}" != 2* ]] 
 then 
    echo "Github API response error:
 ${json2}"

--- a/libexec/kopsenv-version
+++ b/libexec/kopsenv-version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
-version="0.13.0"
+version="1.0.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kopsenv; then


### PR DESCRIPTION
This PR resolves the following:      
- New spot version releases no longer need to be hardcoded into the kopsenv codebase.   
- It's now possible to use either vanilla or spotinst versions of kops.    
- It's now possible to easily upgrade to different releases of spotinst which have the same version, but different SHA, which include some additional fixes
- kopsenv list-remote now prints error details when calls to github API fail, instead of simply succeeding with an empty output

Note: This version contains a breaking change. Instead of assuming that specific version numbers use spotinst, these now need to be explicitly referenced. Example: setting v1.18.2 would previously use spotinst version v1.18.2-6837c742a1, and now it would use the vanilla kops v1.18.2. In order to use spotinst version configurations that reference it should instead reference v1.18.2-6837c742a1-spotinst .         
